### PR TITLE
OJP landing fix

### DIFF
--- a/source/game/bg_pmove.c
+++ b/source/game/bg_pmove.c
@@ -4740,7 +4740,7 @@ static void PM_CrashLand( void ) {
 	//[CoOp]
 	//falling to death NPCs pavement smear.
 #ifdef QAGAME
-	if ( g_entities[pm->ps->clientNum].NPC && g_entities[pm->ps->clientNum].NPC->aiFlags & NPCAI_DIE_ON_IMPACT )
+	if ( g_entities[pm->ps->clientNum].NPC && g_entities[pm->ps->clientNum].NPC->aiFlags & NPCAI_DIE_ON_IMPACT && !pm->ps->m_iVehicleNum)
 	{//have to do death on impact if we are falling to our death, FIXME: should we avoid any additional damage this func?
 		PM_CrashLandDamage( 1000 );
 	}
@@ -16942,3 +16942,4 @@ qboolean PM_GettingUpFromKnockDown( float standheight, float crouchheight )
 	return qfalse;
 }
 //[/KnockdownSys]
+


### PR DESCRIPTION
The problem with vehicles getting damage when landing is something that actually exists only within OJP and its forks, due to the code here that's supposed to provide basically an insta-kill to NPCs falling for extensive lengths.

The code didn't make an exception for vehicles that are technically considered falling entities when landing, resulting in vehicles getting lots of damage and potentially being instakilled when trying to land. 

This is the way to fix it so there's no damage when landing, unless when surface isn't flat enough and collision occurs.